### PR TITLE
fix: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-build-validation.yml
+++ b/.github/workflows/docker-build-validation.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/NovoNordisk-OpenSource/openstudybuilder-accelerators/security/code-scanning/1](https://github.com/NovoNordisk-OpenSource/openstudybuilder-accelerators/security/code-scanning/1)

To fix the issue, explicitly add a `permissions` block to the workflow that restricts the GITHUB_TOKEN to the minimum required permission. Since the job only checks out the repository (which only needs `contents: read`), this is sufficient and secure. The permissions block can be added at the root of the workflow file (applies to all jobs unless overridden).  
The change required is to insert:

```yaml
permissions:
  contents: read
```

directly after the `name: CI` block (line 4), before the `on:` key.  
No code-level changes, imports, or definitions are necessary for this fix — only an edit of the workflow YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
